### PR TITLE
BS/133 : Update pixi from v0.44 to v0.47

### DIFF
--- a/.github/actions/setup-cbh-pixi/action.yml
+++ b/.github/actions/setup-cbh-pixi/action.yml
@@ -3,7 +3,7 @@ name: "Setup CBH Pixi"
 inputs:
   pixi-version:
     description: "Pixi version"
-    default: "v0.44.0"
+    default: "v0.47.0"
     required: false
     type: string
   enviroment:


### PR DESCRIPTION
To use args within pixi we are a single minor version off! I've increased the pixi version to 0.47, which is the latest.