### PR TITLE
Make auth-token optional in setup-cbh-pixi

### DIFF
--- a/.github/actions/setup-cbh-pixi/action.yml
+++ b/.github/actions/setup-cbh-pixi/action.yml
@@ -12,8 +12,9 @@ inputs:
     required: false
     type: string
   auth-token:
-    description: "Prefix.dev API Key"
-    required: true
+    description: "Prefix.dev API Key. If empty, pixi authentication is skipped."
+    required: false
+    default: ""
     type: string
 
 runs:
@@ -24,7 +25,7 @@ runs:
       with:
         pixi-version: ${{ inputs.pixi-version }}
         cache: true
-        auth-host: prefix.dev
+        auth-host: ${{ inputs.auth-token != '' && 'prefix.dev' || '' }}
         auth-token: ${{ inputs.auth-token }}
         frozen: true
         environments: ${{ inputs.enviroment }}


### PR DESCRIPTION
Makes auth-token optional. When empty, skips pixi auth login. Existing callers passing a token are unaffected.

Needed for [TECH-750](https://linear.app/cellbauhaus/issue/TECH-750) —. biohaus no longer needs prefix auth after dropping cellconda.

We can remove this entirely at the point we've completely eradicated usage.